### PR TITLE
Update WordCount Regular Expression

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -22,7 +22,7 @@ class Pref:
 		Pref.modified               = False
 		Pref.elapsed_time           = 0.4
 		Pref.running                = False
-		Pref.wrdRx                  = re.compile("^[^\w]?\w{1,}[^\w]?$", re.U)
+		Pref.wrdRx                  = re.compile("^\S+$", re.U)
 		Pref.wrdRx                  = Pref.wrdRx.match
 		Pref.enable_live_count      = s.get('enable_live_count', True)
 		Pref.enable_readtime        = s.get('enable_readtime', False)

--- a/WordCount.py
+++ b/WordCount.py
@@ -22,7 +22,7 @@ class Pref:
 		Pref.modified               = False
 		Pref.elapsed_time           = 0.4
 		Pref.running                = False
-		Pref.wrdRx                  = re.compile("^\S+$", re.U)
+		Pref.wrdRx                  = re.compile("^\W*\w+.*$", re.U)
 		Pref.wrdRx                  = Pref.wrdRx.match
 		Pref.enable_live_count      = s.get('enable_live_count', True)
 		Pref.enable_readtime        = s.get('enable_readtime', False)


### PR DESCRIPTION
Changing the regular expression to a simpler form. Expressing the same idea. There is one concern is that in my opinion the line 25 of the code:

``` python
Pref.wrdRx                  = re.compile("^\S+$", re.U)
```

should only be:

``` python
Pref.wrdRx                  = re.compile("\S+", re.U)
```

without the **^** and **$** symbols. But since the original codes have them I point it out here for us for consideration.

[edited title by tito]
