### PR TITLE
Take care of all non-space characters separation (not just space or tab characters)

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -209,7 +209,7 @@ class WordCountThread(threading.Thread):
 
 		#=====2
 		wrdRx = Pref.wrdRx
-		words = len([x for x in content.replace('\t', ' ').replace('\n', ' ').split(' ') if False == x.isdigit() and wrdRx(x)])
+		words = len([x for x in content.split() if False == x.isdigit() and wrdRx(x)])
 
 		#Pref.elapsed_time = end = time.time() - begin;
 		#print 'Benchmark: '+str(end)


### PR DESCRIPTION
As we can see, white-space characters in python is not just **'\n', '\t' or ' '**. As demonstrated in the command command line

``` python
>>> string.whitespace
'\t\n\x0b\x0c\r '
```

If we run the function **split()** in python without arguments, it will split words for us using those white-space characters. It helps reduce the issue with some corner case. 
