### PR TITLE
Add option to include whitespace in character count

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -35,6 +35,7 @@ class Pref:
 		Pref.enable_line_char_count = s.get('enable_line_char_count', False)
 		Pref.enable_count_lines     = s.get('enable_count_lines', False)
 		Pref.enable_count_chars     = s.get('enable_count_chars', False)
+		Pref.char_ignore_whitespace = s.get('char_ignore_whitespace', True)
 		Pref.readtime_wpm           = s.get('readtime_wpm', 200)
 		Pref.whitelist              = [x.lower() for x in s.get('whitelist_syntaxes', []) or []]
 		Pref.blacklist              = [x.lower() for x in s.get('blacklist_syntaxes', []) or []]
@@ -181,13 +182,19 @@ class WordCountThread(threading.Thread):
 		self.word_count      = sum([self.count(region) for region in self.content])
 
 		if Pref.enable_count_chars and not self.on_selection:
-			self.char_count      = sum([len(''.join(region.split())) for region in self.content])
+			if Pref.char_ignore_whitespace:
+				self.char_count  = sum([len(''.join(region.split())) for region in self.content])
+			else:
+				self.char_count  = sum([len(region) for region in self.content])
 
 		if Pref.enable_line_word_count:
 			self.word_count_line = self.count(self.content_line)
 
 		if Pref.enable_line_char_count:
-			self.chars_in_line = len(''.join(self.content_line.split()))
+			if Pref.char_ignore_whitespace:
+				self.chars_in_line = len(''.join(self.content_line.split()))
+			else:
+				self.chars_in_line = len(self.content_line.split())
 
 		sublime.set_timeout(lambda:self.on_done(), 0)
 

--- a/WordCount.sublime-settings
+++ b/WordCount.sublime-settings
@@ -3,6 +3,7 @@
 
 	"enable_readtime": false,
 	"readtime_wpm": 200,
+	"char_ignore_whitespace": true,
 
 	"enable_line_word_count": false,
 	"enable_line_char_count": false,

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 Provides a real-time Word Count and character count in the status-bar for Sublime Text. See: http://www.sublimetext.com/
 
-Count words and/or characters on document or in selections. In characters whitespace is not counted.
+Count words and/or characters on document or in selections. By default, whitespace is not included in the character count.
 
 The minimal word length is 1 and does not count digits.
 
@@ -36,6 +36,10 @@ An estimated reading time is now appended to the end of the word count.
 		An array of syntax names that WordCount should not run on.
 		Example: ["Plain text", "Markdown"]
 		If the array is empty, like it is by default, WordCount will run on any syntax.
+
+ - `char_ignore_whitespace` : true
+
+		Whether to skip whitespace for the character count.
 
  - `enable_line_word_count` : false
 


### PR DESCRIPTION
I wanted to see the full character count so I added it as a configuration option. I saw that this was changed in a previous commit, so the default is to ignore whitespace to maintain the current functionality.
