### PR TITLE
Changed calculation of page count

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -151,11 +151,7 @@ class WordCount(sublime_plugin.EventListener):
 				status.append('%d Lines' % (view.rowcol(view.size())[0] + 1))
 
 		if Pref.enable_count_pages:
-			visible = view.visible_region()
-			rows = (view.rowcol(visible.end())[0]) - (view.rowcol(visible.begin())[0]) +1
-			pages = ceil((view.rowcol(view.size())[0] + 1 ) /  rows)
-			if pages > 1:
-				status.append('%d Pages' % pages)
+			status.append(self.makePlural('Pages', word_count / 300))
 
 		if Pref.enable_readtime and s >= 1:
 			status.append("~%dm %ds reading time" % (m, s))

--- a/WordCount.py
+++ b/WordCount.py
@@ -40,6 +40,7 @@ class Pref:
 		Pref.enable_count_lines     = s.get('enable_count_lines', False)
 		Pref.enable_count_chars     = s.get('enable_count_chars', False)
 		Pref.enable_count_pages     = s.get('enable_count_pages', True)
+		Pref.words_per_page         = s.get('words_per_page', 300)
 		Pref.char_ignore_whitespace = s.get('char_ignore_whitespace', True)
 		Pref.readtime_wpm           = s.get('readtime_wpm', 200)
 		Pref.whitelist              = [x.lower() for x in s.get('whitelist_syntaxes', []) or []]
@@ -151,7 +152,9 @@ class WordCount(sublime_plugin.EventListener):
 				status.append('%d Lines' % (view.rowcol(view.size())[0] + 1))
 
 		if Pref.enable_count_pages:
-			status.append(self.makePlural('Pages', word_count / 300))
+			if Pref.words_per_page != 0:
+				page_count = ceil(word_count / Pref.words_per_page)
+				status.append(self.makePlural('Pages', page_count))
 
 		if Pref.enable_readtime and s >= 1:
 			status.append("~%dm %ds reading time" % (m, s))

--- a/WordCount.sublime-settings
+++ b/WordCount.sublime-settings
@@ -12,6 +12,7 @@
 	"enable_count_lines": false,
 
 	"enable_count_pages": true,
+	"words_per_page": 300,
 
 	"whitelist_syntaxes": [],
 	"blacklist_syntaxes": ["CSS","SQL","JavaScript","Python","PHP","JSON"],

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,10 @@ An estimated reading time is now appended to the end of the word count.
 
 		Display the number of pages in file
 
+ - `words_per_page` : 300
+
+		Sets the number of words per page used to calculate number of pages
+
  - `word_regexp` : ""
 
 		Word Regular expression. Defaults empty, an internal regular expression is used. If the portion of text matches this RegExp then the word is counted.


### PR DESCRIPTION
Changed the calculation from visual page size to number of words. 300 is the default, which is a reasonable estimate of the number of words on a page in a novel. 

I am not sure if this is a desired change. A page_count_mode parameter could be introduced in order to switch the behavior.

Best regards,
Nick
