### PR TITLE
Fix line_char_count

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -217,7 +217,7 @@ class WordCountThread(threading.Thread):
 			if Pref.char_ignore_whitespace:
 				self.chars_in_line = len(''.join(self.content_line.split()))
 			else:
-				self.chars_in_line = len(self.content_line.split())
+				self.chars_in_line = len(self.content_line)
 
 		sublime.set_timeout(lambda:self.on_done(), 0)
 

--- a/WordCount.py
+++ b/WordCount.py
@@ -215,7 +215,7 @@ class WordCountThread(threading.Thread):
 
 		if Pref.enable_line_char_count:
 			if Pref.char_ignore_whitespace:
-				self.chars_in_line = len(''.join(self.content_line.split()))
+				self.chars_in_line = sum(len(s) for s in self.content_line.split())
 			else:
 				self.chars_in_line = len(self.content_line)
 


### PR DESCRIPTION
When char_ignore_white_space is set to :false the word count is displaying on the char_line_count instead of the number of characters. This fixes that problem and displays the correct value.
